### PR TITLE
Make ebs_raid resource usable without a `snapshots` attribute

### DIFF
--- a/providers/ebs_raid.rb
+++ b/providers/ebs_raid.rb
@@ -345,7 +345,7 @@ def create_raid_disks(mount_point, mount_point_owner, mount_point_group, mount_p
       device "/dev/#{disk_dev_path}"
       name disk_dev_path
       action [:create, :attach]
-      snapshot_id creating_from_snapshot ? snapshots[i - 1] : ''
+      snapshot_id creating_from_snapshot ? snapshots[i - 1] : nil
       provider 'aws_ebs_volume'
 
       # set up our data bag info


### PR DESCRIPTION
Doing this in our fork so that we're not blocked on that fact that `ebs_raid` is currently broken in the upstream cookboook.

See opscode-cookbooks/aws#156 for details.